### PR TITLE
Fix for non Cordova platform catch error response

### DIFF
--- a/src/pages/core/auth.service.ts
+++ b/src/pages/core/auth.service.ts
@@ -73,7 +73,9 @@ export class AuthService {
          .signInWithPopup(new firebase.auth.GoogleAuthProvider())
          .then((user) => {
             resolve()
-         })
+         },(err) => {
+          reject(err);
+        })
        }
      })
    }
@@ -100,7 +102,12 @@ export class AuthService {
           firebase.auth().currentUser.updateProfile({
             displayName: result.user.displayName,
             photoURL: bigImgUrl
-          }).then(res => resolve());
+          }).then(res => resolve()
+          ,(err) => {
+            reject(err);
+          });
+        },(err) => {
+          reject(err);
         })
       }
     })
@@ -137,7 +144,11 @@ export class AuthService {
           firebase.auth().currentUser.updateProfile({
             displayName: result.user.displayName,
             photoURL: bigImgUrl
-          }).then(res => resolve());
+          }).then(res => resolve(),(err) => {
+            reject(err);
+          });
+        },(err) => {
+          reject(err);
         })
       }
     })


### PR DESCRIPTION
In the file "auth.service.ts" is missing the "err" response to reject for non Cordova platforms.

Trying this app with "ionic serve -l" I realized tht when the user closes the pop up window at Google Login, it crash with a message error.